### PR TITLE
Zabbix services fix:

### DIFF
--- a/extras/envs/dev/ansible/zabbix/tasks.yml
+++ b/extras/envs/dev/ansible/zabbix/tasks.yml
@@ -115,6 +115,9 @@
     name: zabbix-server
     enabled: yes
     state: started
+    # XXX This parameter is needed because without it, zabbix-server service
+    #  doesnt start on a system reload
+    use: service
 
 - name: Configure Zabbix Agent
   notify: restart-zabbix-agent
@@ -130,3 +133,6 @@
     name: zabbix-agent
     enabled: yes
     state: started
+    # XXX This parameter is needed because without it, zabbix-agent service
+    #  doesnt start on a system reload
+    use: service


### PR DESCRIPTION
On ansible/zabbix/tasks.yml on "Enable & start Zabbix XXX service",
added the parameter "use" with value "service", this makes that ansible
uses init instead of systemd (systemd isnt working well for zabbix
services).